### PR TITLE
Fix for browsersync options override default values

### DIFF
--- a/src/config/ingredients/browserSync.js
+++ b/src/config/ingredients/browserSync.js
@@ -2,14 +2,13 @@ module.exports = function(options = {}) {
     if (this.dependencies(["browser-sync", "browser-sync-webpack-plugin"])) {
         return;
     }
-    Object.assign(options, {
-        host: "localhost",
-        port: 3000,
-        proxy: "http://localhost:8888",
-        files: "**/*"
-    });
     const BrowserSyncPlugin = require("browser-sync-webpack-plugin");
     return this.mergeConfig({
-        plugins: [new BrowserSyncPlugin(options)]
+        plugins: [new BrowserSyncPlugin(Object.assign({
+            host: "localhost",
+            port: 3000,
+            proxy: "http://localhost:8888",
+            files: "**/*"
+        }, options))]
     });
 };


### PR DESCRIPTION
This PR resolves the issue where BrowserSync config overrides were not persisting.

cc @elpete 