### PR TITLE
Fix for @next not found on install

### DIFF
--- a/src/config/ingredients/vue.js
+++ b/src/config/ingredients/vue.js
@@ -9,8 +9,8 @@ module.exports = function(
     if (
         this.dependencies([
             "@babel/plugin-syntax-jsx@^7",
-            "@vue/babel-plugin-transform-vue-jsx@next",
-            "@vue/babel-helper-vue-jsx-merge-props@next",
+            "@vue/babel-plugin-transform-vue-jsx@^1",
+            "@vue/babel-helper-vue-jsx-merge-props@^1",
             "vue-loader@^15",
             "vue-template-compiler"
         ])


### PR DESCRIPTION
Resolves the following errors on elixir instantiation:

```
Error: Command failed: npm install sass-loader @babel/plugin-syntax-jsx@^7 @vue/babel-plugin-transform-vue-jsx@next @vue/babel-helper-vue-jsx-merge-props@next vue-loader@^15 vue-template-compiler --save-dev
npm ERR! code ETARGET
npm ERR! notarget No matching version found for @vue/babel-plugin-transform-vue-jsx@next.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.
```

```
Error: Command failed: npm install sass-loader @babel/plugin-syntax-jsx@^7 @vue/babel-plugin-transform-vue-jsx@next @vue/babel-helper-vue-jsx-merge-props vue-loader@^15 vue-template-compiler --save-dev 
npm ERR! code ETARGET
npm ERR! notarget No matching version found for @vue/babel-helper-vue-jsx-merge-props@next.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.

```