### PR TITLE
Update copy method to fix issue #16

### DIFF
--- a/src/config/ingredients/copy.js
+++ b/src/config/ingredients/copy.js
@@ -1,7 +1,7 @@
 const { CleanWebpackPlugin } = require("clean-webpack-plugin");
 
 module.exports = function(from, to) {
-    if (this.dependencies(["copy-webpack-plugin@6.x"])) {
+    if (this.dependencies(["copy-webpack-plugin@6"])) {
         return;
     }
     const CopyWebpackPlugin = require("copy-webpack-plugin");

--- a/src/config/ingredients/copy.js
+++ b/src/config/ingredients/copy.js
@@ -1,13 +1,13 @@
 const { CleanWebpackPlugin } = require("clean-webpack-plugin");
 
 module.exports = function(from, to) {
-    if (this.dependencies(["copy-webpack-plugin"])) {
+    if (this.dependencies(["copy-webpack-plugin@6.x"])) {
         return;
     }
     const CopyWebpackPlugin = require("copy-webpack-plugin");
     return this.mergeConfig({
         plugins: [
-            new CopyWebpackPlugin([{ from, to }]),
+            new CopyWebpackPlugin({ patterns: [ { from: from, to: to } ] }),
             new CleanWebpackPlugin({ cleanOnceBeforeBuildPatterns: [to] })
         ]
     });


### PR DESCRIPTION
This PR includes the following changes:

- Update the dependency reference in `copy.js` to only pull from within `Copy-Webpack-Plugin@6` to avoid any future breaking changes.
- Update syntax in `copy.js` to comply with the new major version.

Docs Note:

There are no updates to the documentation needed with these changes unless it is desired to note the update of the external plugin. I'm happy to file a PR for that if so.

Test Note:

I saw there was no test suite for `copy.js`. I wanted to commit that but I'm less familiar with the workflow of testing those modules. I was able to test for the plugin not existing (similar to other tests) but not sure how to add the plugin and test for its config to exist from the test itself. Happy to commit a suite with some guidance.