### PR TITLE
Revert breaking change from V3

### DIFF
--- a/src/utils/cssLoaders.js
+++ b/src/utils/cssLoaders.js
@@ -10,7 +10,8 @@ module.exports = function cssLoaders(options = {}) {
     const cssLoader = {
         loader: "css-loader",
         options : {
-            sourceMap : true
+            sourceMap : true,
+            url: false
         }
     };
 


### PR DESCRIPTION
Prevent css-loader from trying to modify URLs.  This was a breaking change from V3 that is not needed.